### PR TITLE
Fix password button on mobile

### DIFF
--- a/lib/at_pwd_form.js
+++ b/lib/at_pwd_form.js
@@ -4,7 +4,7 @@ Template.atPwdForm.helpers(AccountsTemplates.atPwdFormHelpers);
 // Simply 'inherites' events from AccountsTemplates
 Template.atPwdForm.events(AccountsTemplates.atPwdFormEvents);
 
-// Fix password button not working on mobile
+// Use the polymer button to submit the form, it can't trigger submit events
 pwdFormSubmit = AccountsTemplates.atPwdFormEvents["submit #at-pwd-form"]
 
 Template.atPwdForm.events({

--- a/lib/at_pwd_form.js
+++ b/lib/at_pwd_form.js
@@ -3,3 +3,10 @@ Template.atPwdForm.helpers(AccountsTemplates.atPwdFormHelpers);
 
 // Simply 'inherites' events from AccountsTemplates
 Template.atPwdForm.events(AccountsTemplates.atPwdFormEvents);
+
+// Fix password button not working on mobile
+pwdFormSubmit = AccountsTemplates.atPwdFormEvents["submit #at-pwd-form"]
+
+Template.atPwdForm.events({
+  "click .at-btn.submit": pwdFormSubmit,
+});

--- a/lib/at_pwd_form_btn.html
+++ b/lib/at_pwd_form_btn.html
@@ -1,6 +1,5 @@
 <template name="atPwdFormBtn">
   <div class="horizontal layout center-justified">
-  	<button type="submit" id="at-btn" hidden></button>
     <paper-button class="at-btn submit {{submitDisabled}}" role="button" id="at-btn-polymer" raised>
       {{buttonText}}
     </paper-button>

--- a/lib/at_pwd_form_btn.js
+++ b/lib/at_pwd_form_btn.js
@@ -1,10 +1,2 @@
 // Simply 'inherites' helpers from AccountsTemplates
 Template.atPwdFormBtn.helpers(AccountsTemplates.atPwdFormBtnHelpers);
-
-
-Template.atPwdFormBtn.events = {
-	'click #at-btn-polymer': function(event,template) {
-		event.preventDefault();
-		template.find('button[type=submit]').click();
-	}
-};


### PR DESCRIPTION
Password buttons don't work on mobile because they require triggering the click event of a hidden button to submit the form, which doesn't work anymore on newer Android and iOS versions.

The new way gets a reference to the submit function and calls it when the polymer submit button is clicked.

The old hidden submit button and code has been removed. Fixes ThaumRystra/DiceCloud#67